### PR TITLE
Restart ui app fix bg resolved events 140142016 jukka

### DIFF
--- a/SensorbergSDK/BackgroundTaskManager.cs
+++ b/SensorbergSDK/BackgroundTaskManager.cs
@@ -45,6 +45,39 @@ namespace SensorbergSDK
         }
 
         /// <summary>
+        /// Will remove OnProgress event handlers from advertisement background task
+        /// OnProgress events are used to indicate UI tasks on beacon actions resolved in background
+        /// </summary>
+        public void UnRegisterOnProgressEventHandler()
+        {
+            System.Diagnostics.Debug.WriteLine("UnRegisterOnProgressEventHandler");
+
+            foreach (var taskValue in BackgroundTaskRegistration.AllTasks.Values)
+            {
+                if (taskValue.Name.Equals(ADVERTISEMENT_CLASS))
+                {
+                    taskValue.Progress -= OnAdvertisementWatcherBackgroundTaskProgress;
+                }
+            }
+        }
+        /// <summary>
+        /// Will remove OnProgress event handlers from advertisement background task
+        /// OnProgress events are used to indicate UI tasks on beacon actions resolved in background
+        /// </summary>
+        public void RegisterOnProgressEventHandler()
+        {
+            System.Diagnostics.Debug.WriteLine("RegisterOnProgressEventHandler");
+
+            foreach (var taskValue in BackgroundTaskRegistration.AllTasks.Values)
+            {
+                if (taskValue.Name.Equals(ADVERTISEMENT_CLASS))
+                {
+                    taskValue.Progress += OnAdvertisementWatcherBackgroundTaskProgress;
+                }
+            }
+        }
+
+        /// <summary>
         /// Checks if the background filters are up-to-date or not. To update the filters,
         /// unregister and register background task again
         /// (call BackgroundTaskManager.UpdateBackgroundTaskAsync()).

--- a/SensorbergSDK/SDKManager.cs
+++ b/SensorbergSDK/SDKManager.cs
@@ -283,7 +283,7 @@ namespace SensorbergSDK
         public static void Dispose()
         {
             ServiceManager.BeaconScanner.StopWatcher();
-            _instance?._backgroundTaskManager.UnregisterBackgroundTask();
+          //  _instance?._backgroundTaskManager.UnregisterBackgroundTask();
             _instance?.SdkEngine.Deinitialize();
             _instance = null;
         }
@@ -295,6 +295,7 @@ namespace SensorbergSDK
         {
             SdkEngine = new SDKEngine(true);
             _backgroundTaskManager = new BackgroundTaskManager();
+            _backgroundTaskManager.RegisterOnProgressEventHandler();
         }
 
         /// <summary>

--- a/SensorbergSDK/SDKManager.cs
+++ b/SensorbergSDK/SDKManager.cs
@@ -332,7 +332,7 @@ namespace SensorbergSDK
                 await UpdateBackgroundTaskIfNeededAsync(timerClassName, advertisementClassName);
             }
 
-          //  StartScanner();
+            StartScanner();
         }
 
         private void OnSettingsUpdated(object sender, SettingsEventArgs settingsEventArgs)

--- a/SensorbergSDK/SDKManager.cs
+++ b/SensorbergSDK/SDKManager.cs
@@ -283,7 +283,7 @@ namespace SensorbergSDK
         public static void Dispose()
         {
             ServiceManager.BeaconScanner.StopWatcher();
-          //  _instance?._backgroundTaskManager.UnregisterBackgroundTask();
+            _instance?._backgroundTaskManager.UnregisterBackgroundTask();
             _instance?.SdkEngine.Deinitialize();
             _instance = null;
         }
@@ -332,7 +332,7 @@ namespace SensorbergSDK
                 await UpdateBackgroundTaskIfNeededAsync(timerClassName, advertisementClassName);
             }
 
-            StartScanner();
+          //  StartScanner();
         }
 
         private void OnSettingsUpdated(object sender, SettingsEventArgs settingsEventArgs)


### PR DESCRIPTION
When We exit the UI apps, the background tasks are still running. thus when we re-start the UI app, we don't will not register the background tasks, and thus originally the event handlers were not set.

Thus, I added event handler adding in case that we re-start the UI app and we have Background tasks active already.
